### PR TITLE
Fix compilation errors on linux machine

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/source/btle/btle.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/source/btle/btle.h
@@ -24,7 +24,7 @@ extern "C" {
 #include "common/common.h"
 
 #include "ble_srv_common.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 
 error_t     btle_init(void);
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/source/btle/custom/custom_helper.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/source/btle/custom/custom_helper.h
@@ -18,7 +18,7 @@
 #define _CUSTOM_HELPER_H_
 
 #include "common/common.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble/UUID.h"
 #include "ble/GattCharacteristic.h"
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/source/nRF5xGap.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/source/nRF5xGap.h
@@ -39,7 +39,7 @@
     #define YOTTA_CFG_IRK_TABLE_MAX_SIZE BLE_GAP_WHITELIST_IRK_MAX_COUNT
 #endif
 #include "ble/blecommon.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble/GapAdvertisingParams.h"
 #include "ble/GapAdvertisingData.h"
 #include "ble/Gap.h"

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/source/nRF5xGattServer.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/source/nRF5xGattServer.h
@@ -20,7 +20,7 @@
 #include <stddef.h>
 
 #include "ble/blecommon.h"
-#include "headers\ble.h" /* nordic ble */
+#include "headers/ble.h" /* nordic ble */
 #include "ble/Gap.h"
 #include "ble/GattServer.h"
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/source/nRF5xServiceDiscovery.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/source/nRF5xServiceDiscovery.h
@@ -21,7 +21,7 @@
 #include "ble/DiscoveredService.h"
 #include "nRF5xDiscoveredCharacteristic.h"
 
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gattc.h"
 
 class nRF5xGattClient; /* forward declaration */

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/ble_advertising/ble_advertising.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/ble_advertising/ble_advertising.h
@@ -62,7 +62,7 @@
 
 #include <stdint.h>
 #include "nrf_error.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gattc.h"
 #include "ble_advdata.h"
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_advdata.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_advdata.h
@@ -51,7 +51,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "app_util.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_conn_params.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_conn_params.h
@@ -48,7 +48,7 @@
 #define BLE_CONN_PARAMS_H__
 
 #include <stdint.h>
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_srv_common.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_conn_state.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_conn_state.c
@@ -40,7 +40,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "sdk_mapped_flags.h"
 #include "app_error.h"
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_conn_state.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_conn_state.h
@@ -68,7 +68,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "sdk_mapped_flags.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_gatt_db.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_gatt_db.h
@@ -47,7 +47,7 @@
 #define BLE_GATT_DB_H__
 
 #include <stdint.h>
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gattc.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_srv_common.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_srv_common.c
@@ -45,7 +45,7 @@
 #include <string.h>
 #include "nordic_common.h"
 #include "app_error.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 
 bool ble_srv_is_notification_enabled(uint8_t const * p_encoded_data)
 {

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_srv_common.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/common/ble_srv_common.h
@@ -51,7 +51,7 @@
 #include <stdbool.h>
 #include "ble_types.h"
 #include "app_util.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gap.h"
 #include "ble_gatt.h"
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/gatt_cache_manager.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/gatt_cache_manager.h
@@ -42,7 +42,7 @@
 
 #include <stdint.h>
 #include "sdk_errors.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gap.h"
 #include "peer_manager_types.h"
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/gatts_cache_manager.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/gatts_cache_manager.h
@@ -42,7 +42,7 @@
 
 #include <stdint.h>
 #include "sdk_errors.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gap.h"
 #include "peer_manager_types.h"
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/id_manager.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/id_manager.c
@@ -41,7 +41,7 @@
 #include "id_manager.h"
 
 #include <string.h>
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gap.h"
 #include "ble_conn_state.h"
 #include "peer_manager_types.h"

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/id_manager.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/id_manager.h
@@ -42,7 +42,7 @@
 
 #include <stdint.h>
 #include "sdk_errors.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gap.h"
 #include "peer_manager_types.h"
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/peer_manager.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/peer_manager.h
@@ -62,7 +62,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "sdk_common.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gap.h"
 #include "peer_manager_types.h"
 #include "peer_database.h"

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/peer_manager_internal.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/peer_manager_internal.h
@@ -42,7 +42,7 @@
 
 #include <stdint.h>
 #include "sdk_errors.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gap.h"
 #include "peer_manager_types.h"
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/security_dispatcher.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/security_dispatcher.c
@@ -41,7 +41,7 @@
 #include "security_dispatcher.h"
 
 #include <string.h>
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gap.h"
 #include "ble_conn_state.h"
 #include "peer_manager_types.h"

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/security_dispatcher.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/security_dispatcher.h
@@ -42,7 +42,7 @@
 
 #include <stdint.h>
 #include "sdk_errors.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gap.h"
 #include "peer_manager_types.h"
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/security_manager.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/ble/peer_manager/security_manager.h
@@ -42,7 +42,7 @@
 
 #include <stdint.h>
 #include "sdk_errors.h"
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "ble_gap.h"
 #include "peer_manager_types.h"
 #include "security_dispatcher.h"

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/softdevice/common/softdevice_handler/ble_stack_handler_types.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/softdevice/common/softdevice_handler/ble_stack_handler_types.h
@@ -55,7 +55,7 @@ extern "C" {
 #ifdef BLE_STACK_SUPPORT_REQD
 
 #include <stdlib.h>
-#include "headers\ble.h"
+#include "headers/ble.h"
 #include "nrf_sdm.h"
 #include "app_error.h"
 #include "app_util.h"

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/softdevice/common/softdevice_handler/softdevice_handler.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/softdevice/common/softdevice_handler/softdevice_handler.c
@@ -62,7 +62,7 @@
 #elif defined(ANT_STACK_SUPPORT_REQD)
     #include "ant_interface.h"
 #elif defined(BLE_STACK_SUPPORT_REQD)
-    #include "headers\ble.h"
+    #include "headers/ble.h"
 #endif
 
 #define RAM_START_ADDRESS         0x20000000

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/softdevice/common/softdevice_handler/softdevice_handler.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/sdk/softdevice/common/softdevice_handler/softdevice_handler.h
@@ -66,7 +66,7 @@
 #include "ble_stack_handler_types.h"
 #include "ant_stack_handler_types.h"
 #if defined(BLE_STACK_SUPPORT_REQD)
-    #include "headers\ble.h"
+    #include "headers/ble.h"
 #endif
 #include "app_ram_base.h"
 


### PR DESCRIPTION
Change path of include from '\' to '/', which works on linux as well.